### PR TITLE
multimetric chokes on unknown files

### DIFF
--- a/multimetric/__main__.py
+++ b/multimetric/__main__.py
@@ -108,6 +108,8 @@ def main():
     with mp.Pool(processes=_args.jobs) as pool:
         results = [pool.apply(file_process, args=(
             f, _args, _importer)) for f in _args.files]
+        for job in pool:
+            job.join()
 
     for x in results:
         _result["files"][x[1]] = x[0]

--- a/multimetric/__main__.py
+++ b/multimetric/__main__.py
@@ -4,16 +4,13 @@ import os
 import textwrap
 import multiprocessing as mp
 
-import chardet
-from pygments import lexers
 
-from multimetric.cls.importer.filtered import FilteredImporter
 from multimetric.cls.importer.pick import importer_pick
 from multimetric.cls.modules import get_additional_parser_args
 from multimetric.cls.modules import get_modules_calculated
 from multimetric.cls.modules import get_modules_metrics
 from multimetric.cls.modules import get_modules_stats
-
+from multimetric.fp import file_process
 
 def ArgParser():
     parser = argparse.ArgumentParser(
@@ -86,43 +83,6 @@ def ArgParser():
     # Turn all paths to abs-paths right here
     RUNARGS.files = [os.path.abspath(x) for x in RUNARGS.files]
     return RUNARGS
-
-
-def file_process(_file, _args, _importer):
-    res = {}
-    store = {}
-    try:
-        _lexer = lexers.get_lexer_for_filename(_file)
-    except Exception as e:
-        if _args.ignore_lexer_errors:
-            return (res, _file, "unknown", [], store)
-        else:
-            raise
-    try:
-        with open(_file, "rb") as i:
-            _cnt = i.read()
-            _enc = chardet.detect(_cnt)
-            _cnt = _cnt.decode(_enc["encoding"]).encode("utf-8")
-        _localImporter = {k: FilteredImporter(
-            v, _file) for k, v in _importer.items()}
-        tokens = list(_lexer.get_tokens(_cnt))
-        if _args.dump:
-            for x in tokens:
-                print("{}: {} -> {}".format(_file, x[0], str(x[1])))
-        else:
-            _localMetrics = get_modules_metrics(_args, **_localImporter)
-            _localCalc = get_modules_calculated(_args, **_localImporter)
-            for x in _localMetrics:
-                x.parse_tokens(_lexer.name, tokens)
-                res.update(x.get_results())
-                store.update(x.get_internal_store())
-            for x in _localCalc:
-                res.update(x.get_results(res))
-                store.update(x.get_internal_store())
-    except Exception:
-        tokens = []
-    return (res, _file, _lexer.name, tokens, store)
-
 
 def main():
     _args = ArgParser()

--- a/multimetric/__main__.py
+++ b/multimetric/__main__.py
@@ -75,7 +75,7 @@ def ArgParser():
         help="Run x jobs in parallel")
     parser.add_argument(
         "--ignore_lexer_errors",
-        default=False,
+        default=True,
         help="Ignore unparseable files")
     get_additional_parser_args(parser)
     parser.add_argument("files", nargs='+', help="Files to parse")

--- a/multimetric/__main__.py
+++ b/multimetric/__main__.py
@@ -76,6 +76,10 @@ def ArgParser():
         type=int,
         default=1,
         help="Run x jobs in parallel")
+    parser.add_argument(
+        "--ignore_lexer_errors",
+        default=False,
+        help="Ignore unparseable files")
     get_additional_parser_args(parser)
     parser.add_argument("files", nargs='+', help="Files to parse")
     RUNARGS = parser.parse_args()
@@ -87,7 +91,13 @@ def ArgParser():
 def file_process(_file, _args, _importer):
     res = {}
     store = {}
-    _lexer = lexers.get_lexer_for_filename(_file)
+    try:
+        _lexer = lexers.get_lexer_for_filename(_file)
+    except Exception as e:
+        if _args.ignore_lexer_errors:
+            return (res, _file, "unknown", [], store)
+        else:
+            raise
     try:
         with open(_file, "rb") as i:
             _cnt = i.read()

--- a/multimetric/__main__.py
+++ b/multimetric/__main__.py
@@ -108,8 +108,6 @@ def main():
     with mp.Pool(processes=_args.jobs) as pool:
         results = [pool.apply(file_process, args=(
             f, _args, _importer)) for f in _args.files]
-        for job in pool:
-            job.join()
 
     for x in results:
         _result["files"][x[1]] = x[0]

--- a/multimetric/cls/calc/maintenance.py
+++ b/multimetric/cls/calc/maintenance.py
@@ -34,7 +34,6 @@ class MetricBaseCalcMaintenanceIndex(MetricBaseCalc):
             self.__miMethod = MetricBaseCalcMaintenanceIndex.MI_DEFAULT
 
     def get_results(self, metrics):
-        print(metrics)
         try:
             metrics[MetricBaseCalcMaintenanceIndex.METRIC_MAINTAINABILITY_INDEX] = eval(
                 MetricBaseCalcMaintenanceIndex.MI_METHOD[self.__miMethod])

--- a/multimetric/cls/calc/maintenance.py
+++ b/multimetric/cls/calc/maintenance.py
@@ -34,8 +34,12 @@ class MetricBaseCalcMaintenanceIndex(MetricBaseCalc):
             self.__miMethod = MetricBaseCalcMaintenanceIndex.MI_DEFAULT
 
     def get_results(self, metrics):
-        metrics[MetricBaseCalcMaintenanceIndex.METRIC_MAINTAINABILITY_INDEX] = eval(
-            MetricBaseCalcMaintenanceIndex.MI_METHOD[self.__miMethod])
+        print(metrics)
+        try:
+            metrics[MetricBaseCalcMaintenanceIndex.METRIC_MAINTAINABILITY_INDEX] = eval(
+                MetricBaseCalcMaintenanceIndex.MI_METHOD[self.__miMethod])
+        except Exception as e:
+            metrics[MetricBaseCalcMaintenanceIndex.METRIC_MAINTAINABILITY_INDEX]=0
         # Sanity
         metrics[MetricBaseCalcMaintenanceIndex.METRIC_MAINTAINABILITY_INDEX] = max(
             metrics[MetricBaseCalcMaintenanceIndex.METRIC_MAINTAINABILITY_INDEX], 0)

--- a/multimetric/cls/calc/tiobe.py
+++ b/multimetric/cls/calc/tiobe.py
@@ -5,6 +5,15 @@ from multimetric.cls.metric.cyclomatic import MetricBaseCyclomaticComplexity
 from multimetric.cls.metric.fanout import MetricBaseFanout
 from multimetric.cls.metric.loc import MetricBaseLOC
 
+def fail_safe(fn):
+    def wrapper(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as e:
+            return 0
+    return wrapper
+
+
 
 class MetricBaseCalcTIOBE(MetricBaseCalc):
 
@@ -21,24 +30,29 @@ class MetricBaseCalcTIOBE(MetricBaseCalc):
     def __init__(self, args, **kwargs):
         super().__init__(args, **kwargs)
         self.__addArgs = kwargs
-
+    
+    @fail_safe
     def __getScaledValue(self, metrics, value):
         return 100.0 / ((value) / (metrics[MetricBaseLOC.METRIC_LOC] / 1000.0) + 1.0)
 
+    @fail_safe
     def __getFromImporter(self, section, _default=0.0):
         if "import_{}".format(section) in self.__addArgs:
             return self.__addArgs["import_{}".format(section)].getSumItems()
         return _default
 
+    @fail_safe
     def __getTiobeComplexity(self, metrics):
         cc = metrics[MetricBaseCyclomaticComplexity.METRIC_CYCLOMATIC_COMPLEXITY]
         return 6400.0 / float(math.pow(cc, 3) - math.pow(cc, 2) - cc + 65)
 
+    @fail_safe
     def __getTiobeFanout(self, metrics):
         _int = metrics[MetricBaseFanout.METRIC_FANOUT_INTERNAL]
         _ext = metrics[MetricBaseFanout.METRIC_FANOUT_EXTERNAL]
         return float(min(max(120.0 - ((8.0 * _int) + (2.0 * _ext)), 0.0), 100.0))
 
+    @fail_safe
     def __getTiobeCoverage(self, metrics):
         _per = self.__getFromImporter("coverage", _default=100.0)
         if _per < 1.0:
@@ -46,25 +60,31 @@ class MetricBaseCalcTIOBE(MetricBaseCalc):
             return 0.0
         return min(((0.75 * _per) + 32.5), 100.0)
 
+    @fail_safe
     def __getTiobeStandard(self, metrics):
         return self.__getScaledValue(metrics, self.__getFromImporter("standard"))
 
+    @fail_safe
     def __getTiobeSecurity(self, metrics):
         return self.__getScaledValue(metrics, self.__getFromImporter("security"))
 
+    @fail_safe
     def __getTiobeDuplication(self, metrics):
         return min(-30.0 * math.log10(self.__getFromImporter("duplication") or 0.00001) +
                    70.0, 100.0)
-
+    
+    @fail_safe
     def __getTiobeCompiler(self, metrics):
         _violations = self.__getScaledValue(metrics, self.__getFromImporter("compiler"))
         return max(100.0 - 50.0 *
                    math.log((101 - _violations) or 0.00001), 0.0)
 
+    @fail_safe
     def __getTiobeFunctional(self, metrics):
         _violations = self.__getFromImporter("functional")
         return max(self.__getScaledValue(metrics, _violations) * 2.0 - 100.0, 0.0)
 
+    @fail_safe
     def __getTiobe(self, metrics):
         return (metrics[MetricBaseCalcTIOBE.METRIC_TIOBE_COVERAGE] * 0.2) + \
                (metrics[MetricBaseCalcTIOBE.METRIC_TIOBE_FUNCTIONAL] * 0.2) + \

--- a/multimetric/fp.py
+++ b/multimetric/fp.py
@@ -1,3 +1,4 @@
+import sys
 import chardet
 from pygments import lexers
 
@@ -15,6 +16,8 @@ def file_process(_file, _args, _importer):
         _lexer = lexers.get_lexer_for_filename(_file)
     except Exception as e:
         if _args.ignore_lexer_errors:
+            # Printing to stderr since we write results to STDOUT
+            print("Processing unknown file type: " + _file, file=sys.stderr)
             return (res, _file, "unknown", [], store)
         else:
             raise

--- a/multimetric/fp.py
+++ b/multimetric/fp.py
@@ -1,0 +1,44 @@
+import chardet
+from pygments import lexers
+
+from multimetric.cls.importer.pick import importer_pick
+from multimetric.cls.modules import get_additional_parser_args
+from multimetric.cls.modules import get_modules_calculated
+from multimetric.cls.modules import get_modules_metrics
+from multimetric.cls.modules import get_modules_stats
+from multimetric.cls.importer.filtered import FilteredImporter
+
+def file_process(_file, _args, _importer):
+    res = {}
+    store = {}
+    try:
+        _lexer = lexers.get_lexer_for_filename(_file)
+    except Exception as e:
+        if _args.ignore_lexer_errors:
+            return (res, _file, "unknown", [], store)
+        else:
+            raise
+    try:
+        with open(_file, "rb") as i:
+            _cnt = i.read()
+            _enc = chardet.detect(_cnt)
+            _cnt = _cnt.decode(_enc["encoding"]).encode("utf-8")
+        _localImporter = {k: FilteredImporter(
+            v, _file) for k, v in _importer.items()}
+        tokens = list(_lexer.get_tokens(_cnt))
+        if _args.dump:
+            for x in tokens:
+                print("{}: {} -> {}".format(_file, x[0], str(x[1])))
+        else:
+            _localMetrics = get_modules_metrics(_args, **_localImporter)
+            _localCalc = get_modules_calculated(_args, **_localImporter)
+            for x in _localMetrics:
+                x.parse_tokens(_lexer.name, tokens)
+                res.update(x.get_results())
+                store.update(x.get_internal_store())
+            for x in _localCalc:
+                res.update(x.get_results(res))
+                store.update(x.get_internal_store())
+    except Exception:
+        tokens = []
+    return (res, _file, _lexer.name, tokens, store)

--- a/multimetric/fp.py
+++ b/multimetric/fp.py
@@ -2,11 +2,8 @@ import sys
 import chardet
 from pygments import lexers
 
-from multimetric.cls.importer.pick import importer_pick
-from multimetric.cls.modules import get_additional_parser_args
 from multimetric.cls.modules import get_modules_calculated
 from multimetric.cls.modules import get_modules_metrics
-from multimetric.cls.modules import get_modules_stats
 from multimetric.cls.importer.filtered import FilteredImporter
 
 def file_process(_file, _args, _importer):


### PR DESCRIPTION
Should at least have an option to ignore lexer errors.

This situation should never happen:
```
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/multimetric/__main__.py", line 90, in file_process
    _lexer = lexers.get_lexer_for_filename(_file)
  File "/Users/jason/Library/Python/3.8/lib/python/site-packages/pygments/lexers/__init__.py", line 209, in get_lexer_for_filename
    raise ClassNotFound('no lexer for filename %r found' % _fn)
pygments.util.ClassNotFound: no lexer for filename '/Users/jason/atd/temp_repo/.gitignore' found
"""
```