### PR TITLE
Fix Maintainabillity index Calculation

### DIFF
--- a/multimetric/cls/calc/maintenance.py
+++ b/multimetric/cls/calc/maintenance.py
@@ -72,9 +72,9 @@ class MetricBaseCalcMaintenanceIndex(MetricBaseCalc):
 
         """
         try:
-            res = 171.0 - (5.2 * math.log2(metrics["halstead_volume"]))
+            res = 171.0 - (5.2 * math.log(metrics["halstead_volume"]))
             res -= 0.23 * metrics["cyclomatic_complexity"]
-            res -= 16.2 * math.log2(metrics["loc"])
+            res -= 16.2 * math.log(metrics["loc"])
             res += 50.0 * abs(math.sin(math.sqrt(2.4 * metrics["comment_ratio"])))
             return res
         except ValueError:  # pragma: no cover
@@ -126,7 +126,8 @@ class MetricBaseCalcMaintenanceIndex(MetricBaseCalc):
             res = 171.0
             res -= 5.2 * math.log(metrics["halstead_volume"])
             res -= 0.23 * metrics["cyclomatic_complexity"]
-            res -= 16.2 * math.log(metrics["loc"]) * 100.0 / 171.0
+            res -= 16.2 * math.log(metrics["loc"])
+            res *= 100.0 / 171.0
             return max(0, res)
         except ValueError:
             return 0
@@ -179,8 +180,8 @@ class MetricBaseCalcMaintenanceIndex(MetricBaseCalc):
 
     MI_METHOD = {
         "sei": _mi_sei,
-        "classic": _mi_microsoft,
-        "microsoft": _mi_classic,
+        "classic": _mi_classic,
+        "microsoft": _mi_microsoft,
     }
 
     def __init__(self, args, **kwargs):

--- a/multimetric/cls/calc/maintenance.py
+++ b/multimetric/cls/calc/maintenance.py
@@ -155,19 +155,18 @@ class MetricBaseCalcMaintenanceIndex(MetricBaseCalc):
         -----
         This method uses the following formula[1]_ to calculate the maintenance index:
 
-        171 - 5.2 x ln(aveVol) - 0.23 x aveV(g’) - 16.2 x ln(aveLoC) + (50 x sin(sqrt(2.46 x perCM)))
+        171 - 5.2 x ln(aveVol) - 0.23 x aveV(g’) - 16.2 x ln(aveLoC)
 
         where:
             - aveVol is average Halstead Volume
             - aveV(g’) is average extended cyclomatic complexity per module
             - aveLoC is average Lines Of Code
-            - perCM is percent of comments per module
 
         The result is returned as a float value, higher is better.
 
         References
         ----------
-        .. [1] https://www.ecs.csun.edu/~rlingard/comp589/ColemanPaper.pdf
+        .. [1] https://learn.microsoft.com/en-us/visualstudio/code-quality/code-metrics-maintainability-index-range-and-meaning?view=vs-2022
         """
         try:
             res = 171.0
@@ -226,11 +225,4 @@ class MetricBaseCalcMaintenanceIndex(MetricBaseCalc):
         metrics[
             MetricBaseCalcMaintenanceIndex.METRIC_MAINTAINABILITY_INDEX
         ] = MetricBaseCalcMaintenanceIndex.MI_METHOD[self.__miMethod](metrics)
-        # Sanity
-        metrics[MetricBaseCalcMaintenanceIndex.METRIC_MAINTAINABILITY_INDEX] = max(
-            metrics[MetricBaseCalcMaintenanceIndex.METRIC_MAINTAINABILITY_INDEX], 0,
-        )
-        metrics[MetricBaseCalcMaintenanceIndex.METRIC_MAINTAINABILITY_INDEX] = min(
-            metrics[MetricBaseCalcMaintenanceIndex.METRIC_MAINTAINABILITY_INDEX], 100,
-        )
         return super().get_results(metrics)

--- a/tests/test_bash.py
+++ b/tests/test_bash.py
@@ -39,7 +39,7 @@ class TestClassBash():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 47.143
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 164.999
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 13
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 101.977
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 18
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 14
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 19

--- a/tests/test_c.py
+++ b/tests/test_c.py
@@ -39,7 +39,7 @@ class TestClassC():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 800.259
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 620.0
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 28
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 82.204
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 41
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 15
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 83

--- a/tests/test_calc_maintenance.py
+++ b/tests/test_calc_maintenance.py
@@ -28,27 +28,27 @@ class TestClassMaintenance():
 
         res, _, _ = self._run(file)
 
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 82.204
 
     def test_maintenance_sei(self):
         file = os.path.join(pytest.test_dir_local, 'test.c')
 
         res, _, _ = self._run(file, '--maintindex', 'sei')
 
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 87.281
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 125.979
 
     def test_maintenance_classic(self):
         file = os.path.join(pytest.test_dir_local, 'test.c')
 
         res, _, _ = self._run(file, '--maintindex', 'classic')
 
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 82.204
 
     def test_maintenance_microsoft(self):
         file = os.path.join(pytest.test_dir_local, 'test.c')
 
         res, _, _ = self._run(file, '--maintindex', 'microsoft')
 
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 82.204
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 48.072
 
 

--- a/tests/test_coffeescript.py
+++ b/tests/test_coffeescript.py
@@ -39,7 +39,7 @@ class TestClassCoffeeScript():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 628.24
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 689.753
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 19
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 88.161
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 89
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 38
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 32

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -39,7 +39,7 @@ class TestClassCPP():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 2442.23
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 986.285
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 31
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 77.681
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 78
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 14
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 123

--- a/tests/test_csharp.py
+++ b/tests/test_csharp.py
@@ -39,7 +39,7 @@ class TestClassCSharp():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 1767.624
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 1156.991
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 47
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 96.926
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 71.029
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 70
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 28
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 135

--- a/tests/test_dart.py
+++ b/tests/test_dart.py
@@ -39,7 +39,7 @@ class TestClassDart():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 200.776
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 324.33
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 12
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100.219
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 26
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 14
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 43

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -39,7 +39,7 @@ class TestClassGo():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 528.809
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 475.928
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 15
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 94.15
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 40
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 14
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 59

--- a/tests/test_groovy.py
+++ b/tests/test_groovy.py
@@ -39,7 +39,7 @@ class TestClassGroovy():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 323.571
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 376.519
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 20
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 90.708
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 33
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 16
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 43

--- a/tests/test_haskell.py
+++ b/tests/test_haskell.py
@@ -39,7 +39,7 @@ class TestClassHaskell():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 5069.351
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 2144.844
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 59
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 90.872
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 63.446
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 141
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 58
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 187

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -39,7 +39,7 @@ class TestClassJava():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 1339.315
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 1132.33
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 45
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 97.68
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 72.075
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 88
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 31
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 117

--- a/tests/test_javascript.py
+++ b/tests/test_javascript.py
@@ -39,7 +39,7 @@ class TestClassJavaScript():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 655.674
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 759.677
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 25
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 83.213
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 58
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 28
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 82

--- a/tests/test_julia.py
+++ b/tests/test_julia.py
@@ -39,7 +39,7 @@ class TestClassJulia():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 352.917
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 495.0
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 22
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 87.741
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 49
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 21
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 50

--- a/tests/test_kotlin.py
+++ b/tests/test_kotlin.py
@@ -39,7 +39,7 @@ class TestClassKotlin():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 290.537
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 452.784
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 16
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 93.594
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 33
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 20
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 56

--- a/tests/test_lisp.py
+++ b/tests/test_lisp.py
@@ -39,7 +39,7 @@ class TestClassLisp():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 22.116
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 113.738
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 15
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 102.053
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 7
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 3
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 37

--- a/tests/test_lua.py
+++ b/tests/test_lua.py
@@ -39,7 +39,7 @@ class TestClassLua():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 344.877
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 419.227
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 14
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 95.008
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 55
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 13
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 42

--- a/tests/test_objective_c.py
+++ b/tests/test_objective_c.py
@@ -39,7 +39,7 @@ class TestClassObjectiveC():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 4009.982
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 2298.434
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 86
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 87.403
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 57.442
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 142
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 52
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 227

--- a/tests/test_perl.py
+++ b/tests/test_perl.py
@@ -39,7 +39,7 @@ class TestClassPerl():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 23.441
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 105.486
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 13
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 104.533
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 7
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 7
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 20

--- a/tests/test_php.py
+++ b/tests/test_php.py
@@ -39,7 +39,7 @@ class TestClassPHP():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 225.857
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 271.029
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 16
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 95.802
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 24
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 12
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 33

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -39,7 +39,7 @@ class TestClassPython():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 5342.3
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 2012.255
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 32
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 97.23
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 73.919
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 166
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 33
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 187

--- a/tests/test_rust.py
+++ b/tests/test_rust.py
@@ -39,7 +39,7 @@ class TestClassRust():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 2514.892
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 1512.252
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 42
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 96.599
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 71.459
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 91
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 38
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 162

--- a/tests/test_tcl.py
+++ b/tests/test_tcl.py
@@ -39,7 +39,7 @@ class TestClassTcl():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 5.076
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 68.532
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 6
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 119.532
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 16
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 12
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 2

--- a/tests/test_typescript.py
+++ b/tests/test_typescript.py
@@ -39,7 +39,7 @@ class TestClassTypeScript():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 163.147
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 301.195
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 6
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 111.833
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 24
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 16
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 38

--- a/tests/test_zig.py
+++ b/tests/test_zig.py
@@ -39,7 +39,7 @@ class TestClassZig():
         assert res.get('files', {}).get(file, {}).get('halstead_timerequired', 0) == 137.992
         assert res.get('files', {}).get(file, {}).get('halstead_volume', 0) == 254.754
         assert res.get('files', {}).get(file, {}).get('loc', 0) == 8
-        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 100
+        assert res.get('files', {}).get(file, {}).get('maintainability_index', 0) == 108.043
         assert res.get('files', {}).get(file, {}).get('operands_sum', 0) == 26
         assert res.get('files', {}).get(file, {}).get('operands_uniq', 0) == 12
         assert res.get('files', {}).get(file, {}).get('operators_sum', 0) == 32


### PR DESCRIPTION
Fix For https://github.com/priv-kweihmann/multimetric/issues/80

* We shouldn't clamp the maintainability index between 0-100 as only Microsoft metric is between 0-100 and the others are not clamped. 
* Fixed that classic and Microsoft callbacks where switched.
* Fixed calculation of Microsoft Index as it only multiplied the lines of code *100/171.
* Fixed using ln instead of log2 as described in the resources.
* Changed reference to microsoft for classic maintainability as the reference showed the SEI index and the formular was also the SEI Index (not aligning with the actual calculation)
