### PR TITLE
ci: move to python-build

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Install dependencies
       if: steps.release-needed.outputs.DO_RELEASE == 'true'
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip build
         pip install -r requirements.txt
     
     - name: Bump version
@@ -98,7 +98,7 @@ jobs:
     - name: Build
       if: steps.release-needed.outputs.DO_RELEASE == 'true'
       run: |
-        python3 setup.py build sdist bdist_wheel --universal
+        python -m build --sdist --wheel
 
     - name: Commit new version
       if: steps.release-needed.outputs.DO_RELEASE == 'true'

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,12 +18,12 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip build
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
     - name: Lint
       run: flake8
     - name: Build
-      run: python3 setup.py build
+      run: python3 -m build --sdist --wheel
     - name: Test
       run: pytest


### PR DESCRIPTION
as directly calling setup.py is deprecated

# Pull request checklist

## General

- [x] [Contribution guideline](../CONTRIBUTING.md) was read and accepted

